### PR TITLE
POC for adaptive md support

### DIFF
--- a/src/model/CodeSample.js
+++ b/src/model/CodeSample.js
@@ -1,7 +1,7 @@
-import { splitTextLines, spacesIntoTabs } from '../utils/text';
-import { initEmptyContent2dArray } from './redux/correctness';
+import { spacesIntoTabs, splitTextLines } from '../utils/text';
 import resolver from '../modules/resolver';
 import { parseSkipMask } from './parseSkipMask';
+import convertMarkdownFile from './convertMarkdownFile';
 
 const textCharsLimit = 20000;
 
@@ -12,6 +12,7 @@ export default async function CreateCodeSample({ fileName, content, html_url, cr
 
   let contentAsLines = splitTextLines(text);
   contentAsLines = spacesIntoTabs(contentAsLines);
+  contentAsLines = convertMarkdownFile(contentAsLines, fileName);
   const contentAs2dArray = contentAsLines.map((line) => line.split(''));
   const subDivisions = await resolver(contentAsLines, fileName);
   const skipMask2dArray = parseSkipMask(contentAs2dArray, subDivisions);
@@ -36,68 +37,4 @@ export default async function CreateCodeSample({ fileName, content, html_url, cr
     html_url,
     credentials,
   };
-}
-
-export function parseSkipMask(contentAs2dArray, subDivisions) {
-  let skipMask2dArr = initEmptyContent2dArray(contentAs2dArray);
-
-  for (let ln = 0; ln < subDivisions.length; ln++) {
-    for (let tn = 0; tn < subDivisions[ln].length; tn++) {
-      const t = subDivisions[ln][tn];
-      if (t.tokenType === 1) {
-        const [start, end] = t.ltRange;
-        //  0 - no skip, 1 - start skip, 2 - inner skip, 3 - end skip
-        const commentsArray = new Array(end - start + 1).fill(2);
-        commentsArray[0] = 1;
-        commentsArray[commentsArray.length - 1] = 3;
-
-        skipMask2dArr[ln] = [
-          ...skipMask2dArr[ln].slice(0, start),
-          ...commentsArray,
-          ...skipMask2dArr[ln].slice(end, skipMask2dArr[ln].length - 1),
-        ];
-      }
-    }
-
-    // Special cases:
-    for (let c = 0; c < skipMask2dArr[ln].length; c++) {
-      // Skip characters
-      if (
-        contentAs2dArray[ln][c] === '\t' || // tabs
-        contentAs2dArray[ln][c].charCodeAt(0) > 126 // non ASCII chars
-      ) {
-        skipMask2dArr[ln][c] = resolveSkipCode(skipMask2dArr[ln], c);
-      }
-    }
-
-    // In case the the last char in the line is "\n", replace it like it was the last char in comment
-    if (
-      skipMask2dArr[ln][skipMask2dArr[ln].length - 2] === 3 &&
-      contentAs2dArray[ln][contentAs2dArray[ln].length - 1] === '\n'
-    ) {
-      skipMask2dArr[ln][skipMask2dArr[ln].length - 2] = 2;
-      skipMask2dArr[ln][skipMask2dArr[ln].length - 1] = 3;
-    }
-  }
-
-  return skipMask2dArr;
-}
-
-function resolveSkipCode(skipMaskLine, skipCursor) {
-  if (skipCursor === 0 || skipMaskLine[skipCursor - 1] === 0) {
-    return 1;
-  }
-
-  if (skipMaskLine[skipCursor + 1] === 0 || skipCursor === skipMaskLine.length - 1) {
-    // back step adjusting
-    if (skipMaskLine[skipCursor - 1] === 3) {
-      skipMaskLine[skipCursor - 1] = 2;
-    }
-
-    return 3;
-  }
-
-  if (skipMaskLine[skipCursor - 1] === 1 || skipMaskLine[skipCursor - 1] === 2) {
-    return 2;
-  }
 }

--- a/src/model/convertMarkdownFile.js
+++ b/src/model/convertMarkdownFile.js
@@ -1,0 +1,37 @@
+// This is MVP for supporting basic interpretation for .MD files
+// As a base feature it only extracts the code for limited number of
+// supported extensions. In future, the supported extensions probably
+// should be handled via remote API.
+// Currently all the langs handled as Javascript language syntax for simplicity,
+// which also could be extended in future.
+
+const supportedExt = ['css', 'jsx', 'js', 'ts', 'py', 'shell'];
+
+function isParsingStringOpen(line) {
+  for (let i = 0; i < supportedExt.length; i++) {
+    if (line.startsWith('```' + supportedExt[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+export default function convertMarkdownFile(contentAsLines, fileName) {
+  const ext = fileName.split('.').pop();
+
+  if (ext === 'md') {
+    let isTagOpen = false;
+    const filteredTextLines = [];
+    for (let i = 0; i < contentAsLines.length; i++) {
+      if (contentAsLines[i].startsWith('```\n')) {
+        isTagOpen = false;
+        filteredTextLines.push('\n');
+      }
+      if (isTagOpen) filteredTextLines.push(contentAsLines[i]);
+      if (isParsingStringOpen(contentAsLines[i])) isTagOpen = true;
+    }
+    contentAsLines = filteredTextLines;
+  }
+
+  return contentAsLines;
+}

--- a/src/model/parseSkipMask.js
+++ b/src/model/parseSkipMask.js
@@ -1,46 +1,9 @@
-import { splitTextLines, spacesIntoTabs } from '../utils/text';
-import { initEmptyContent2dArray } from './redux/correctness';
-import resolver from '../modules/resolver';
-import { parseSkipMask } from './parseSkipMask';
-
-const textCharsLimit = 20000;
-
-export default async function CreateCodeSample({ fileName, content, html_url, credentials }) {
-  let text = decodeURIComponent(escape(window.atob(content)));
-  text = text.replaceAll('\ufeff', '');
-  if (text.length > textCharsLimit) text = text.slice(0, textCharsLimit);
-
-  let contentAsLines = splitTextLines(text);
-  contentAsLines = spacesIntoTabs(contentAsLines);
-  const contentAs2dArray = contentAsLines.map((line) => line.split(''));
-  const subDivisions = await resolver(contentAsLines, fileName);
-  const skipMask2dArray = parseSkipMask(contentAs2dArray, subDivisions);
-  // Gather final amount of successful letters
-  let totalChars = 0;
-  for (let i = 0; i < skipMask2dArray.length; i++) {
-    for (let j = 0; j < skipMask2dArray[i].length; j++) {
-      if (skipMask2dArray[i][j] === 0) totalChars++;
-    }
-  }
-
-  return {
-    id: Math.random().toString(36).slice(2),
-    title: fileName,
-    contentAsLines,
-    contentAs2dArray,
-    skipMask2dArray,
-    subDivisions,
-    totalChars,
-    contentLinesLen: contentAs2dArray.length,
-    createdAt: new Date().getTime(),
-    html_url,
-    credentials,
-  };
-}
+import { initEmptyContent2dArray } from '../utils/array';
 
 export function parseSkipMask(contentAs2dArray, subDivisions) {
   let skipMask2dArr = initEmptyContent2dArray(contentAs2dArray);
 
+  // Work with tokens
   for (let ln = 0; ln < subDivisions.length; ln++) {
     for (let tn = 0; tn < subDivisions[ln].length; tn++) {
       const t = subDivisions[ln][tn];
@@ -59,7 +22,7 @@ export function parseSkipMask(contentAs2dArray, subDivisions) {
       }
     }
 
-    // Special cases:
+    // Handle special cases:
     for (let c = 0; c < skipMask2dArr[ln].length; c++) {
       // Skip characters
       if (

--- a/src/model/redux/correctness.js
+++ b/src/model/redux/correctness.js
@@ -1,3 +1,5 @@
+import { initEmptyContent2dArray } from '../../utils/array';
+
 /**
  * Correctness map is basic state of the app.
  * It closely combined with basic stats like correctAmount, keysLeft, mistakes, isComplete for the sake of performance.
@@ -42,14 +44,6 @@ const CHAR_STATE = {
   SUCCESS: 1,
   MISTAKE: 2,
 };
-
-export function initEmptyContent2dArray(contentAs2dArray) {
-  const emptyContentAs2dArray = new Array(contentAs2dArray.length);
-  for (let i = 0; i < contentAs2dArray.length; i++) {
-    emptyContentAs2dArray[i] = new Array(contentAs2dArray[i].length).fill(0);
-  }
-  return emptyContentAs2dArray;
-}
 
 // prev
 function resolveStats(command, state, prevCharState, totalChars) {

--- a/src/utils/array.js
+++ b/src/utils/array.js
@@ -1,0 +1,7 @@
+export function initEmptyContent2dArray(contentAs2dArray) {
+  const emptyContentAs2dArray = new Array(contentAs2dArray.length);
+  for (let i = 0; i < contentAs2dArray.length; i++) {
+    emptyContentAs2dArray[i] = new Array(contentAs2dArray[i].length).fill(0);
+  }
+  return emptyContentAs2dArray;
+}


### PR DESCRIPTION
Introduces the basic adaptive parsing for .md files (filters out non-code stuff).
POC is very basic and limitations described in notes.

<img width="1026" alt="image" src="https://user-images.githubusercontent.com/13506547/177202546-b8f45479-20a5-47cc-b5ba-19f7a08287c4.png">
<img width="1239" alt="image" src="https://user-images.githubusercontent.com/13506547/177202562-c64be8f2-cbd6-4d15-8c53-a3470410ad04.png">


Could be tested with urs:
https://github.com/30-seconds/30-seconds-of-git/blob/master/snippets/apply-latest-stash.md
https://github.com/30-seconds/30-seconds-of-code/blob/master/snippets/addClass.md
https://github.com/30-seconds/30-seconds-of-python/blob/master/snippets/find.md
https://github.com/30-seconds/30-seconds-of-css/blob/master/snippets/etched-text.md

or from localhost
http://localhost:3000/30-seconds/30-seconds-of-git/blob/master/snippets/apply-latest-stash.md
http://localhost:3000/30-seconds/30-seconds-of-code/blob/master/snippets/addClass.md
http://localhost:3000/30-seconds/30-seconds-of-python/blob/master/snippets/find.md
http://localhost:3000/30-seconds/30-seconds-of-css/blob/master/snippets/etched-text.md
